### PR TITLE
Fix three-database initialization SQL errors

### DIFF
--- a/github-actions-backend/scripts/create-three-dbs.js
+++ b/github-actions-backend/scripts/create-three-dbs.js
@@ -9,7 +9,7 @@ const Database = require('better-sqlite3');
 const path = require('path');
 const fs = require('fs');
 
-const dataDir = path.join(__dirname, 'data');
+const dataDir = path.join(__dirname, '..', 'data');
 
 // Ensure data directory exists
 if (!fs.existsSync(dataDir)) {

--- a/github-actions-backend/scripts/init-db-three.js
+++ b/github-actions-backend/scripts/init-db-three.js
@@ -40,8 +40,15 @@ function loadCompanyConfig() {
   }
 }
 
+// Check if companies table exists first
+const tableExists = intelligenceDb.prepare(`
+  SELECT name FROM sqlite_master 
+  WHERE type='table' AND name='companies'
+`).get();
+
 // Insert initial companies if database is empty
-const companyCount = intelligenceDb.prepare('SELECT COUNT(*) as count FROM companies').get().count;
+const companyCount = tableExists ? 
+  intelligenceDb.prepare('SELECT COUNT(*) as count FROM companies').get().count : 0;
 
 if (companyCount === 0) {
   console.log('📊 Inserting comprehensive AI landscape companies...');
@@ -326,9 +333,19 @@ if (companyCount === 0) {
 }
 
 // Display database statistics
+const companiesTableExists = intelligenceDb.prepare(`
+  SELECT name FROM sqlite_master WHERE type='table' AND name='companies'
+`).get();
+
+const urlsTableExists = intelligenceDb.prepare(`
+  SELECT name FROM sqlite_master WHERE type='table' AND name='urls'
+`).get();
+
 const stats = {
-  companies: intelligenceDb.prepare('SELECT COUNT(*) as count FROM companies').get().count,
-  urls: intelligenceDb.prepare('SELECT COUNT(*) as count FROM urls').get().count
+  companies: companiesTableExists ? 
+    intelligenceDb.prepare('SELECT COUNT(*) as count FROM companies').get().count : 0,
+  urls: urlsTableExists ? 
+    intelligenceDb.prepare('SELECT COUNT(*) as count FROM urls').get().count : 0
 };
 
 console.log('\n📊 Database Statistics:');


### PR DESCRIPTION
## 🔧 Fixes

This PR fixes the SQL errors that were preventing the three-database architecture from initializing properly.

### Problem
1. The `init-db-three.js` script was trying to query the `companies` table before checking if it exists
2. The `create-three-dbs.js` was creating databases in the wrong directory (`scripts/data/` instead of `data/`)

### Solution
1. Added table existence checks before any SQL queries
2. Fixed the data directory path to match where `db-manager.js` expects the databases

### Changes
- **init-db-three.js**: Added SQL checks for table existence before counting rows
- **create-three-dbs.js**: Fixed data directory path from `__dirname/data` to `__dirname/../data`

### Testing
These changes will allow the scrape workflow to run successfully with the three-database architecture enabled.

Fixes the issue discovered in workflow run #15864173970