### PR TITLE
🔧 Fix git push failure in sync workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -129,13 +129,31 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           
+          # FIXED: Pull latest changes before attempting to push
+          git pull origin main --rebase
+          
           git add api-data/ || true
           
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else
             git commit -m "🚀 Deploy updates - $(date -u +%Y-%m-%d\ %H:%M:%S\ UTC)"
-            git push
+            # Use retry logic for push in case of race conditions
+            for i in 1 2 3; do
+              if git push; then
+                echo "✅ Successfully pushed changes"
+                break
+              else
+                echo "⚠️  Push failed, attempt $i/3"
+                if [ $i -lt 3 ]; then
+                  echo "Pulling latest changes and retrying..."
+                  git pull origin main --rebase
+                else
+                  echo "❌ Failed to push after 3 attempts"
+                  exit 1
+                fi
+              fi
+            done
           fi
       
       # Deploy to GitHub Pages


### PR DESCRIPTION
## Fix for Git Push Failure in Sync Workflow

This PR fixes the recurring "Updates were rejected" error we've been experiencing in the Sync & Deploy workflow.

### Problem
The workflow was failing with:
```
! [rejected] main -> main (fetch first)
error: failed to push some refs to 'https://github.com/redmorestudio/ai-competitive-monitor'
hint: Updates were rejected because the remote contains work that you do not have locally.
```

This happens when multiple workflows run concurrently and try to push changes to the main branch.

### Solution
1. **Pull before push**: Added `git pull origin main --rebase` before attempting to push
2. **Retry logic**: Implemented a retry mechanism with up to 3 attempts
3. **Pull and retry on failures**: If a push fails, we pull the latest changes and try again

### Changes Made
- Modified the "Commit final updates" step in `.github/workflows/sync.yml`
- Added proper error handling and retry logic
- Clear status messages for each attempt

This should resolve the race condition issues and ensure our workflows complete successfully even when multiple instances are running.