### PR TITLE
🐛 Fix TheBrain sync - use Node.js instead of Python

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -106,7 +106,7 @@ jobs:
             echo "   Skipping TheBrain sync..."
           else
             echo "🧠 Syncing to TheBrain via API..."
-            python thebrain_api_sync.py || echo "TheBrain sync completed"
+            node thebrain-api-sync.js || echo "TheBrain sync completed"
           fi
         env:
           THEBRAIN_API_KEY: ${{ secrets.THEBRAIN_API_KEY }}


### PR DESCRIPTION
# Fix TheBrain Sync Command 🐛

## Problem
The TheBrain sync has been failing because the workflow was trying to run a JavaScript file with Python:
```bash
python thebrain_api_sync.py  # ❌ Wrong - it's a .js file!
```

## Solution
This PR changes the command to use Node.js:
```bash
node thebrain-api-sync.js  # ✅ Correct
```

## Details
- The `thebrain-api-sync.js` file is a fully functional JavaScript implementation that uses axios to make real API calls
- The workflow was mistakenly trying to run it with Python, causing the sync to fail silently
- This one-line fix will enable the TheBrain integration to actually work

## Testing
After merging:
1. Run the Sync & Deploy workflow manually
2. Check the logs for "🧠 Syncing to TheBrain via API..."
3. Verify thoughts and links appear in the Competitive-monitor brain

## Related
- API Key and Brain ID are already configured in secrets
- The API implementation is complete and tested
- This fixes the issue documented in #10