### PR TITLE
Critical Fix: Restore database persistence in scrape workflow

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -84,14 +84,32 @@ jobs:
           cd github-actions-backend
           npx puppeteer browsers install chrome
       
+      # NEW STEP: Download previous database artifact to maintain historical data
+      - name: Download previous database artifact
+        id: download-artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: scrape.yml
+          workflow_conclusion: success
+          name: scraper-databases-*
+          path: github-actions-backend/data
+          if_no_artifact_found: warn
+        continue-on-error: true
+      
       - name: Initialize database (three-db architecture)
         if: ${{ env.USE_THREE_DB == 'true' }}
         run: |
           cd github-actions-backend
           
-          # Run the three-database initialization
-          echo "📊 Initializing three-database architecture..."
-          node scripts/init-db-three.js
+          # Check if we have existing databases from artifact
+          if [ -f data/raw_content.db ] && [ -f data/intelligence.db ]; then
+            echo "✅ Using existing databases from previous run"
+            echo "📊 Database sizes:"
+            ls -lh data/*.db
+          else
+            echo "📊 No previous databases found, initializing fresh..."
+            node scripts/init-db-three.js
+          fi
       
       - name: Initialize database (legacy)
         if: ${{ env.USE_THREE_DB != 'true' }}
@@ -181,8 +199,8 @@ jobs:
           echo "📦 Stashing any uncommitted changes..."
           git stash push -m "Temporary stash during workflow" || true
           
-          # Add the databases and scrape status
-          git add -f github-actions-backend/data/raw_content.db || true
+          # NOTE: raw_content.db is gitignored, so we don't try to add it
+          # Only add files that are actually tracked by git
           git add -f github-actions-backend/data/intelligence.db || true
           git add api-data/last-scrape.json || true
           
@@ -213,7 +231,6 @@ jobs:
                     git reset --hard HEAD~1
                     git pull origin main
                     # Re-add and commit our changes
-                    git add -f github-actions-backend/data/raw_content.db || true
                     git add -f github-actions-backend/data/intelligence.db || true
                     git add api-data/last-scrape.json || true
                     git commit -m "🕷️ Update scraped content (three-db) - $(date -u +%Y-%m-%d\ %H:%M:%S\ UTC)"


### PR DESCRIPTION
## 🚨 Critical Fix: Restore Database Persistence in Scrape Workflow

### Problem
The AI competitive monitoring system hasn't detected any changes since July 4, 2025, despite running every 6 hours. Investigation revealed that `raw_content.db` (337MB+) is gitignored, but the workflow was trying to commit it to git. This resulted in each workflow run starting with a fresh database, losing all historical data needed for change detection.

### Root Cause
1. `raw_content.db` is in `.gitignore` (too large for git)
2. Workflow attempts `git add -f raw_content.db` but git ignores it
3. Each run calls `init-db-three.js` which creates a fresh database
4. No historical data = no change detection possible

### Solution
This PR adds a step to download the previous workflow's artifact before initializing the database:
- Uses `dawidd6/action-download-artifact` to get the latest successful run's databases
- Only initializes fresh database if no artifact is found (first run)
- Removes the futile attempt to commit `raw_content.db` to git
- Maintains database persistence through GitHub Actions artifacts

### Changes
1. Added "Download previous database artifact" step before database initialization
2. Modified initialization to check for existing databases first
3. Removed `git add -f raw_content.db` from commit step (only track `intelligence.db`)

### Impact
- Restores change detection functionality
- Will detect all changes that occurred since July 4th on next run
- Prevents future data loss
- Maintains full scraping history within 7-day artifact retention

### Testing
After merging:
1. Run the scrape workflow manually
2. Check logs to confirm "Using existing databases from previous run"
3. Verify change detection finds recent updates (e.g., Replit blog post from July 12)
4. Monitor dashboard should show new changes

### Note
This is a critical fix that restores core functionality. The system has been blind to competitor updates for 11 days.