### PR TITLE
Critical Fix: Add missing GROQ_API_KEY to scrape workflow

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -145,6 +145,7 @@ jobs:
         env:
           GITHUB_ACTIONS: 'true'
           FORCE_SCRAPE: ${{ inputs.force_scrape }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
       
       # REMOVED: Markdown conversion - this belongs in process.yml
       


### PR DESCRIPTION
## 🚨 Critical Fix: Add Missing GROQ_API_KEY to Scrape Workflow

### Problem
The scrape workflow that was triggered after merging PR #62 failed with the error:
```
❌ Fatal error: GroqError: The GROQ_API_KEY environment variable is missing or empty
```

### Root Cause
While the `GROQ_API_KEY` secret exists in the repository settings, it wasn't being passed to the scraper step in the workflow file.

### Solution
This PR adds the `GROQ_API_KEY` to the environment variables in the "Run intelligent scraper" step:
```yaml
env:
  GITHUB_ACTIONS: 'true'
  FORCE_SCRAPE: ${{ inputs.force_scrape }}
  GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}  # <-- Added this line
```

### Impact
- Allows the scraper to use the Groq API for change detection
- Fixes the immediate failure we encountered
- Enables the system to finally detect all changes since July 4th

### Testing
After merging:
1. The scrape workflow should run successfully
2. Database persistence fix from PR #62 will work
3. System will detect ~11 days of missed competitor updates

This is a one-line fix but critical for the system to function.