### PR TITLE
Fix: Workflow git commit issue - properly stage intelligence.db

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -202,19 +202,26 @@ jobs:
           # Remove node_modules that might have been created
           rm -rf node_modules || true
           
-          # Stash any remaining uncommitted changes to ensure clean state
-          echo "📦 Stashing any uncommitted changes..."
-          git stash push -m "Temporary stash during workflow" || true
+          # CRITICAL FIX: Add files BEFORE stashing
+          # Force add the intelligence database (it might be gitignored)
+          echo "📂 Adding intelligence.db..."
+          git add -f github-actions-backend/data/intelligence.db || {
+            echo "⚠️ Failed to add intelligence.db, checking if it exists..."
+            ls -la github-actions-backend/data/
+            exit 1
+          }
           
-          # NOTE: raw_content.db is gitignored, so we don't try to add it
-          # Only add files that are actually tracked by git
-          git add -f github-actions-backend/data/intelligence.db || true
+          # Add the scrape summary
+          echo "📂 Adding last-scrape.json..."
           git add api-data/last-scrape.json || true
+          
+          # Show what will be committed
+          echo "📋 Files staged for commit:"
+          git diff --staged --name-only
           
           # Check if there are changes to commit
           if git diff --staged --quiet; then
             echo "No changes to commit"
-            git stash pop || true  # Restore stashed changes if any
           else
             # Commit the changes
             git commit -m "🕷️ Update scraped content (three-db) - $(date -u +%Y-%m-%d\ %H:%M:%S\ UTC)"
@@ -271,9 +278,6 @@ jobs:
               echo "⚠️  Manual intervention may be required"
               exit 1  # Fail since scraping data is critical
             }
-            
-            # Clean up stash if any
-            git stash pop || true
           fi
       
       - name: Commit database changes (legacy)


### PR DESCRIPTION
## Fix: Workflow Git Commit Issue

This PR fixes the issue where the scrape workflow was modifying the `intelligence.db` file but failing to commit it back to the repository.

### The Problem
In the recent scrape run, the logs showed:
```
modified:   github-actions-backend/data/intelligence.db
no changes added to commit (use "git add" and/or "git commit -a")
```

The workflow was doing `git stash` before `git add`, which was causing the modified files to be stashed away and not staged for commit.

### The Solution
1. **Removed the git stash operation** before adding files
2. **Add files immediately** after cleaning up workspace
3. **Added error checking** when adding intelligence.db
4. **Added logging** to show staged files before commit

### Key Changes
- Moved `git add` operations before any stashing
- Added explicit error checking with `ls -la` if add fails
- Show staged files with `git diff --staged --name-only`
- Removed unnecessary stash pop operations

### Testing
After this fix is deployed:
1. The scrape workflow should successfully commit database changes
2. Check logs for "📋 Files staged for commit:" section
3. Verify intelligence.db is listed in staged files
4. Confirm the commit and push succeed

This fix ensures that all database updates from the scraper are properly persisted to the repository.