### PR TITLE
Remove Git LFS tracking to fix budget exceeded error

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-github-actions-backend/data/raw_content.db filter=lfs diff=lfs merge=lfs -text
+# No LFS tracking - using PostgreSQL for large data storage

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# Database files that are too large (handled by LFS)
-# github-actions-backend/data/raw_content.db is tracked by LFS
+# Database files that are too large (now ignored completely)
+github-actions-backend/data/raw_content.db
 
 # Old database file to ignore
 github-actions-backend/data/monitor.db


### PR DESCRIPTION
## Remove Git LFS to Fix Budget Exceeded Error

This PR removes Git LFS tracking to resolve the "repository exceeded its LFS budget" error that's blocking all GitHub Actions workflows.

### Changes:
1. ✅ Updated `.gitignore` to ignore `raw_content.db` completely
2. ✅ Removed LFS tracking from `.gitattributes`

### Context:
- The system already has PostgreSQL set up and operational for storing raw content
- The SQLite `raw_content.db` file (337MB+) exceeded GitHub's free LFS limits
- PostgreSQL was designed for this exact scenario - unlimited storage in the cloud

### Next Steps After Merge:
1. Run PostgreSQL workflows instead of SQLite for raw content
2. Consider scheduling the PostgreSQL workflows (currently manual only)
3. All raw content will be stored in PostgreSQL, no Git storage needed

This unblocks the workflows immediately and completes the migration to PostgreSQL for raw content storage.